### PR TITLE
Reset closest item and interacting item on each button press.

### DIFF
--- a/Assets/WandController.cs
+++ b/Assets/WandController.cs
@@ -32,6 +32,9 @@ public class WandController : MonoBehaviour {
 
         if (controller.GetPressDown(gripButton) || controller.GetPressDown(triggerButton)) {
             // Find the closest item to the hand in case there are multiple and interact with it
+            closestItem = null;
+			interactingItem = null;
+
             float minDistance = float.MaxValue;
 
             float distance;


### PR DESCRIPTION
If you press the button outside an object after you've already interacted with it, the controller will pick up the last interacting item no mater how far away it is. This fixes the issue.